### PR TITLE
R820t tuner fixes

### DIFF
--- a/src/tuner_r82xx.c
+++ b/src/tuner_r82xx.c
@@ -502,7 +502,7 @@ static int r82xx_set_pll(struct r82xx_priv *priv, uint32_t freq)
 	 */
         
 	vco_div = (pll_ref + 65536 * vco_freq) / (2 * pll_ref);
-        nint = (uint32_t) (vco_div / 65536);
+	nint = (uint32_t) (vco_div / 65536);
 	sdm = (uint32_t) (vco_div % 65536);
 
 #if 0


### PR DESCRIPTION
These changes improve the R820T tuner code to calculate the VCO/PLL parameters more precisely. The old code rounded the reference frequency to the nearest kHz and did some slightly dodgy hand-rolled long division.

These changes empirically reduce the tuning error from approx +/- 750Hz to approx +/- 200Hz.
This is good enough to also fix some odd behaviour with applying frequency corrections, where for some PPM + frequency combinations, changing PPM by +/-1 would have no effect because the underlying tuner imprecision mapped both frequencies to the same PLL settings.

Tested on a generic RTL2832U with R820T tuner only.
