### PR TITLE
Let rtlsdr_set_tuner_if_gain return -1 upon error.

### DIFF
--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -1025,10 +1025,10 @@ int rtlsdr_get_tuner_gain(rtlsdr_dev_t *dev)
 
 int rtlsdr_set_tuner_if_gain(rtlsdr_dev_t *dev, int stage, int gain)
 {
-	int r = 0;
+	int r = -1;
 
 	if (!dev || !dev->tuner)
-		return -1;
+		return r;
 
 	if (dev->tuner->set_if_gain) {
 		rtlsdr_set_i2c_repeater(dev, 1);


### PR DESCRIPTION
Let rtlsdr_set_tuner_if_gain() return -1 when it cannot be set.
That was the case when there is no device, no tuner or when the
value was invalid, but it returned 0 when the there was no way
to set if-gain for the used receiver.
Now it returns also -1 when there is no set-function for if_gain.

Without this patch, a user interface is not aware that the
specified if_gain has not been set when using a tuner without
a set_if_gain() function.