### PR TITLE
Separate functions for setting lna, mixer and vga gains (for r82xx tuner)

### DIFF
--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -169,6 +169,13 @@ RTLSDR_API int rtlsdr_set_freq_correction(rtlsdr_dev_t *dev, int ppm);
  */
 RTLSDR_API int rtlsdr_get_freq_correction(rtlsdr_dev_t *dev);
 
+enum gain_types {
+        lna,
+        mixer,
+        vga,
+	total
+};
+
 enum rtlsdr_tuner {
 	RTLSDR_TUNER_UNKNOWN = 0,
 	RTLSDR_TUNER_E4000,
@@ -214,6 +221,15 @@ RTLSDR_API int rtlsdr_get_tuner_gains(rtlsdr_dev_t *dev, int *gains);
  * \return 0 on success
  */
 RTLSDR_API int rtlsdr_set_tuner_gain(rtlsdr_dev_t *dev, int gain);
+RTLSDR_API int rtlsdr_set_lna_gain(rtlsdr_dev_t *dev, int gain);
+RTLSDR_API int rtlsdr_set_mixer_gain(rtlsdr_dev_t *dev, int gain);
+RTLSDR_API int rtlsdr_set_vga_gain(rtlsdr_dev_t *dev, int gain);
+
+RTLSDR_API int rtlsdr_get_lna_gains(rtlsdr_dev_t *dev, int *gains);
+RTLSDR_API int rtlsdr_get_mixer_gains(rtlsdr_dev_t *dev, int *gains);
+RTLSDR_API int rtlsdr_get_vga_gains(rtlsdr_dev_t *dev, int *gains);
+RTLSDR_API int rtlsdr_get_specific_gains(rtlsdr_dev_t *dev, int *gains, enum gain_types gain_type);
+
 
 /*!
  * Set the bandwidth for the device.

--- a/include/tuner_r82xx.h
+++ b/include/tuner_r82xx.h
@@ -115,6 +115,9 @@ int r82xx_standby(struct r82xx_priv *priv);
 int r82xx_init(struct r82xx_priv *priv);
 int r82xx_set_freq(struct r82xx_priv *priv, uint32_t freq);
 int r82xx_set_gain(struct r82xx_priv *priv, int set_manual_gain, int gain);
+int r82xx_set_lna_gain(struct r82xx_priv *priv, int gain);
+int r82xx_set_mixer_gain(struct r82xx_priv *priv, int gain);
+int r82xx_set_vga_gain(struct r82xx_priv *priv, int gain);
 int r82xx_set_bandwidth(struct r82xx_priv *priv, int bandwidth,  uint32_t rate);
 
 #endif


### PR DESCRIPTION
I am using an rtl-sdr with r820t tuner using rtl_power_fftw for radio astronomy.  I wanted control of the lna gain for the tuner as well as mixer and vga so I made some changes to librtlsdr as well as to rtl_power_fftw to break out that functionality.  

In librtlsdr I added functions for setting lna, mixer and vga gains as well as getting available gains for each.  I added an enum with the gain types "lna", "mixer", "vga" and "total" (where total is the current default) to aid in re-using existing code without breaking current compatibility with code that may be using librtlsdr.

I'm fairly certain that these changes do not break any existing code that uses the library and doesn't seem to cause problems for other tuners which don't support it (I've only tried with an e4000 tuner for checking this).