### PR TITLE
fix builds with newer compilers & C standards

### DIFF
--- a/src/rtl_adsb.c
+++ b/src/rtl_adsb.c
@@ -182,7 +182,7 @@ int magnitute(uint8_t *buf, int len)
 	return len/2;
 }
 
-inline uint16_t single_manchester(uint16_t a, uint16_t b, uint16_t c, uint16_t d)
+static inline uint16_t single_manchester(uint16_t a, uint16_t b, uint16_t c, uint16_t d)
 /* takes 4 consecutive real samples, return 0 or 1, BADSAMPLE on error */
 {
 	int bit, bit_p;
@@ -223,17 +223,17 @@ inline uint16_t single_manchester(uint16_t a, uint16_t b, uint16_t c, uint16_t d
 	return BADSAMPLE;
 }
 
-inline uint16_t min16(uint16_t a, uint16_t b)
+static inline uint16_t min16(uint16_t a, uint16_t b)
 {
 	return a<b ? a : b;
 }
 
-inline uint16_t max16(uint16_t a, uint16_t b)
+static inline uint16_t max16(uint16_t a, uint16_t b)
 {
 	return a>b ? a : b;
 }
 
-inline int preamble(uint16_t *buf, int i)
+static inline int preamble(uint16_t *buf, int i)
 /* returns 0/1 for preamble at index i */
 {
 	int i2;

--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -249,7 +249,7 @@ void sine_table(int size)
 	}
 }
 
-inline int16_t FIX_MPY(int16_t a, int16_t b)
+static inline int16_t FIX_MPY(int16_t a, int16_t b)
 /* fixed point multiply and scale */
 {
 	int c = ((int)a * (int)b) >> 14;


### PR DESCRIPTION
The meaning of "inline" has changed when "static" is not used.
Since none of these functions are used outside of their respective
files, mark them as static to avoid build errors where funcs are
not inlined (based on compiler flags too).