### PR TITLE
output ppm to stderr to avoid flushing stdout buffer

### DIFF
--- a/src/rtl_test.c
+++ b/src/rtl_test.c
@@ -202,7 +202,7 @@ static void ppm_test(uint32_t len)
 	interval += (int64_t)(ppm_now.tv_nsec - ppm_recent.tv_nsec);
 	nsamples_total += nsamples;
 	interval_total += interval;
-	printf("real sample rate: %i current PPM: %i cumulative PPM: %i\n",
+	fprintf(stderr, "real sample rate: %i current PPM: %i cumulative PPM: %i\n",
 		(int)((1000000000UL * nsamples) / interval),
 		ppm_report(nsamples, interval),
 		ppm_report(nsamples_total, interval_total));


### PR DESCRIPTION
Output to stdout is buffered. For interactive console it will be flushed
automatically after \n, for non-interactive it will be flushed only
after fflush(stdout). When calling rtl_test from external process it
unable to read ppm since output was to stdout and there was no fflush