### PR TITLE
Fix memory leak in rtlsdr_open()

### DIFF
--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -1520,6 +1520,10 @@ int rtlsdr_open(rtlsdr_dev_t **out_dev, uint32_t index)
 	r = libusb_claim_interface(dev->devh, 0);
 	if (r < 0) {
 		fprintf(stderr, "usb_claim_interface error %d\n", r);
+		if (dev) 
+		{
+        	libusb_close(dev->devh);
+		}
 		goto err;
 	}
 


### PR DESCRIPTION
Response to issue #49.
Dev->devh was never freed if libusb_claim_interface failed.