### PR TITLE
Add the rtl_biast program to the repository

### DIFF
--- a/include/rtl-sdr.h
+++ b/include/rtl-sdr.h
@@ -389,6 +389,17 @@ RTLSDR_API int rtlsdr_cancel_async(rtlsdr_dev_t *dev);
  */
 RTLSDR_API int rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on);
 
+/*!
+ * Enable or disable the bias tee on the given GPIO pin.
+ *
+ * \param dev the device handle given by rtlsdr_open()
+ * \param gpio the gpio pin to configure as a Bias T control.
+ * \param on  1 for Bias T on. 0 for Bias T off.
+ * \return -1 if device is not initialized. 0 otherwise.
+ */
+RTLSDR_API int rtlsdr_set_bias_tee_gpio(rtlsdr_dev_t *dev, int gpio, int on);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,7 +91,8 @@ add_executable(rtl_fm rtl_fm.c)
 add_executable(rtl_eeprom rtl_eeprom.c)
 add_executable(rtl_adsb rtl_adsb.c)
 add_executable(rtl_power rtl_power.c)
-set(INSTALL_TARGETS rtlsdr_shared rtlsdr_static rtl_sdr rtl_tcp rtl_test rtl_fm rtl_eeprom rtl_adsb rtl_power)
+add_executable(rtl_biast rtl_biast.c)
+set(INSTALL_TARGETS rtlsdr_shared rtlsdr_static rtl_sdr rtl_tcp rtl_test rtl_fm rtl_eeprom rtl_adsb rtl_power rtl_biast)
 
 target_link_libraries(rtl_sdr rtlsdr_shared convenience_static
     ${LIBUSB_LIBRARIES}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,11 @@ target_link_libraries(rtl_power rtlsdr_shared convenience_static
     ${LIBUSB_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
 )
+target_link_libraries(rtl_biast rtlsdr_shared convenience_static
+    ${LIBUSB_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+
 if(UNIX)
 target_link_libraries(rtl_fm m)
 target_link_libraries(rtl_adsb m)

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -2009,13 +2009,19 @@ int rtlsdr_i2c_read_fn(void *dev, uint8_t addr, uint8_t *buf, int len)
 	return -1;
 }
 
-int rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on)
+int rtlsdr_set_bias_tee_gpio(rtlsdr_dev_t *dev, int gpio, int on)
 {
 	if (!dev)
 		return -1;
 
-	rtlsdr_set_gpio_output(dev, 0);
-	rtlsdr_set_gpio_bit(dev, 0, on);
+	rtlsdr_set_gpio_output(dev, gpio);
+	rtlsdr_set_gpio_bit(dev, gpio, on);
 
 	return 0;
+}
+
+int rtlsdr_set_bias_tee(rtlsdr_dev_t *dev, int on)
+{
+
+	return rtlsdr_set_bias_tee_gpio(dev, 0, on);
 }

--- a/src/rtl_biast.c
+++ b/src/rtl_biast.c
@@ -111,14 +111,19 @@ int main(int argc, char **argv)
 	}
 
 	r = rtlsdr_open(&dev, dev_index);
-
-        rtlsdr_set_gpio(dev, gpio_pin, bias_on);
-	//rtlsdr_set_bias_tee(dev, bias_on);
-
-	//rtlsdr_set_direct_sampling(dev, 1);
+	rtlsdr_set_bias_tee_gpio(dev, gpio_pin, bias_on);
 
 exit:
-	rtlsdr_close_bt(dev);
+	/*
+	 * Note - rtlsdr_close() in this tree does not clear the bias tee
+	 * GPIO line, so it leaves the bias tee enabled if a client program
+	 * doesn't explictly disable it.
+	 *
+	 * If that behaviour changes then another rtlsdr_close() will be
+	 * needed that takes some extension flags, and one of them should
+	 * be to either explicitly close the biast or leave it alone.
+	 */
+	rtlsdr_close(dev);
 
 	return r >= 0 ? r : -r;
 }

--- a/src/rtl_biast.c
+++ b/src/rtl_biast.c
@@ -1,0 +1,124 @@
+/*
+ * rtl-sdr, turns your Realtek RTL2832 based DVB dongle into a SDR receiver
+ * rtl_eeprom, EEPROM modification tool
+ * Copyright (C) 2012 by Steve Markgraf <steve@steve-m.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+#else
+#include <windows.h>
+#include "getopt/getopt.h"
+#endif
+
+#include "rtl-sdr.h"
+#include "convenience/convenience.h"
+
+#define EEPROM_SIZE	256
+#define MAX_STR_SIZE	256
+#define STR_OFFSET	0x09
+
+static rtlsdr_dev_t *dev = NULL;
+
+typedef struct rtlsdr_config {
+	uint16_t vendor_id;
+	uint16_t product_id;
+	char manufacturer[MAX_STR_SIZE];
+	char product[MAX_STR_SIZE];
+	char serial[MAX_STR_SIZE];
+	int have_serial;
+	int enable_ir;
+	int remote_wakeup;
+} rtlsdr_config_t;
+
+
+void usage(void)
+{
+	fprintf(stderr,
+		"rtl_biast, a tool for turning the RTL-SDR.com \n"
+		"bias tee or any GPIO ON and OFF. Example to turn on the \n"
+		"bias tee: rtl_biast -d 0 -b 1\n"
+                "Any GPIO: rtl_biast -d 0 -g 1 -b 1\n\n"
+		"Usage:\n"
+		"\t[-d device_index (default: 0)]\n"
+		"\t[-b bias_on (default: 0)]\n"
+                "\t[-g GPIO select (default: 0)]\n");
+	exit(1);
+}
+
+int main(int argc, char **argv)
+{
+	int i, r, opt;
+	int dev_index = 0;
+	int dev_given = 0;
+	uint32_t bias_on = 0;
+        uint32_t gpio_pin = 0;
+	int device_count;
+	char *filename = NULL;
+	FILE *file = NULL;
+	char *manuf_str = NULL;
+	char *product_str = NULL;
+	char *serial_str = NULL;
+	uint8_t buf[EEPROM_SIZE];
+	rtlsdr_config_t conf;
+	int flash_file = 0;
+	int default_config = 0;
+	int change = 0;
+	int ir_endpoint = 0;
+	char ch;
+
+	while ((opt = getopt(argc, argv, "d:b:g:h?")) != -1) {
+		switch (opt) {
+		case 'd':
+			dev_index = verbose_device_search(optarg);
+			dev_given = 1;
+			break;
+		case 'b':
+			bias_on = atoi(optarg);
+			break;
+                case 'g':
+                       gpio_pin = atoi(optarg);
+                       break;
+		default:
+			usage();
+			break;
+		}
+	}
+
+	if (!dev_given) {
+		dev_index = verbose_device_search("0");
+	}
+
+	if (dev_index < 0) {
+		exit(1);
+	}
+
+	r = rtlsdr_open(&dev, dev_index);
+
+        rtlsdr_set_gpio(dev, gpio_pin, bias_on);
+	//rtlsdr_set_bias_tee(dev, bias_on);
+
+	//rtlsdr_set_direct_sampling(dev, 1);
+
+exit:
+	rtlsdr_close_bt(dev);
+
+	return r >= 0 ? r : -r;
+}


### PR DESCRIPTION
This adds the rtl_biast program from the rtlsdrblog github repository.

* add a new program, rtl_biast
* add a new API call to librtlsdr that allows for the bias tee GPIO line to be configured rather than assuming it is always GPIO 0.

tested on freebsd-head, enabled/disabled the biast I'm using here and it works all ok.