### PR TITLE
lib: retry i2c on failure

### DIFF
--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -578,6 +578,7 @@ void rtlsdr_set_gpio_output(rtlsdr_dev_t *dev, uint8_t gpio)
 
 void rtlsdr_set_i2c_repeater(rtlsdr_dev_t *dev, int on)
 {
+	on = !!on; /* values +2 to force on */
 	rtlsdr_demod_write_reg(dev, 1, 0x01, on ? 0x18 : 0x10, 1);
 }
 

--- a/src/librtlsdr.c
+++ b/src/librtlsdr.c
@@ -1995,17 +1995,33 @@ uint32_t rtlsdr_get_tuner_clock(void *dev)
 
 int rtlsdr_i2c_write_fn(void *dev, uint8_t addr, uint8_t *buf, int len)
 {
-	if (dev)
-		return rtlsdr_i2c_write(((rtlsdr_dev_t *)dev), addr, buf, len);
-
+	int r;
+	int retries = 2;
+	if (!dev)
+		return -1;
+	do {
+		r = rtlsdr_i2c_write(((rtlsdr_dev_t *)dev), addr, buf, len);
+		if (r >= 0)
+		    return r;
+		rtlsdr_set_i2c_repeater(dev, 2);
+		retries--;
+	} while (retries > 0);
 	return -1;
 }
 
 int rtlsdr_i2c_read_fn(void *dev, uint8_t addr, uint8_t *buf, int len)
 {
-	if (dev)
-		return rtlsdr_i2c_read(((rtlsdr_dev_t *)dev), addr, buf, len);
-
+	int r;
+	int retries = 2;
+	if (!dev)
+		return -1;
+	do {
+		r = rtlsdr_i2c_read(((rtlsdr_dev_t *)dev), addr, buf, len);
+		if (r >= 0)
+		    return r;
+		rtlsdr_set_i2c_repeater(dev, 2);
+		retries--;
+	} while (retries > 0);
 	return -1;
 }
 


### PR DESCRIPTION
When doing a setFrequency I usually have this error afterwards and the frequency is actually not changed
```
rtlsdr_demod_write_reg failed with -9
r82xx_write: i2c wr failed=-9 reg=17 len=1
r82xx_set_freq: failed=-9
```
This will actually really set the frequency and remove the last 2 errors related to "r82xx"

This is from here : https://github.com/keenerd/rtl-sdr/pull/8/commits/9ed9ffa37e24f3293fa960cfcd74909ac3e9996c

I didn't know how to import just that commit into a PR