### PR TITLE
Fixed issues compiling on Windows with MSVC, CMake and NMake

### DIFF
--- a/cmake/Modules/FindLibUSB.cmake
+++ b/cmake/Modules/FindLibUSB.cmake
@@ -9,7 +9,7 @@ if(NOT LIBUSB_FOUND)
   )
 
 #standard library name for libusb-1.0
-set(libusb1_library_names usb-1.0)
+set(libusb1_library_names usb-1.0 libusb-1.0)
 
 #libusb-1.0 compatible library on freebsd
 if((CMAKE_SYSTEM_NAME STREQUAL "FreeBSD") OR (CMAKE_SYSTEM_NAME STREQUAL "kFreeBSD"))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ RTLSDR_APPEND_SRCS(
 # Set up Windows DLL resource files
 ########################################################################
 IF(MSVC)
-    include(${CMAKE_SOURCE_DIR}/cmake/Modules/Version.cmake)
+    include(${PROJECT_SOURCE_DIR}/cmake/Modules/Version.cmake)
 
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/rtlsdr.rc.in
@@ -146,6 +146,7 @@ target_link_libraries(rtl_fm libgetopt_static)
 target_link_libraries(rtl_eeprom libgetopt_static)
 target_link_libraries(rtl_adsb libgetopt_static)
 target_link_libraries(rtl_power libgetopt_static)
+target_link_libraries(rtl_biast libgetopt_static)
 set_property(TARGET rtl_sdr APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 set_property(TARGET rtl_tcp APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 set_property(TARGET rtl_test APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
@@ -153,6 +154,7 @@ set_property(TARGET rtl_fm APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 set_property(TARGET rtl_eeprom APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 set_property(TARGET rtl_adsb APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 set_property(TARGET rtl_power APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
+set_property(TARGET rtl_biast APPEND PROPERTY COMPILE_DEFINITIONS "rtlsdr_STATIC" )
 endif()
 ########################################################################
 # Install built library files & utilities

--- a/src/rtlsdr.rc.in
+++ b/src/rtlsdr.rc.in
@@ -1,5 +1,5 @@
 
-#include <afxres.h>
+#include <windows.h>
 
 VS_VERSION_INFO VERSIONINFO
   FILEVERSION 0,0,0,0


### PR DESCRIPTION
When trying to build a simple program which uses librtlsdr
as a subproject on Windows, CMake reported several problems
which were solved by:
- Added complete name of libusb in FindLibUSB module.
- Replaced CMAKE_SOURCE_DIR to PROJECT_SOURCE_DIR in src/CMakeLists.txt.
- Replaced header file <afxres.h> in src/rtlsdr.rc.in (only present when windows MFC is
  installed) by <windows.h> which defines the same constants.